### PR TITLE
Escape html before marking it as safe

### DIFF
--- a/lib/breadcrumbs_on_rails/breadcrumbs.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs.rb
@@ -60,7 +60,7 @@ module BreadcrumbsOnRails
             when Proc
               name.call(@context)
             else
-              name.to_s
+              h(name.to_s)
           end
         end
 
@@ -100,7 +100,7 @@ module BreadcrumbsOnRails
       end
 
       def render_element(element)
-        content = @context.link_to_unless_current(compute_name(h(element)), compute_path(element))
+        content = @context.link_to_unless_current(compute_name(element), compute_path(element))
         if @options[:tag]
           @context.content_tag(@options[:tag], content)
         else


### PR DESCRIPTION
Hi Weppos

First of all thanks for a great gem!

I have tried to make a pull request similar to this once before. Now I see you have released a rails 3 version but it is still vulnerable to XSS. You are marking strings as html_safe without sanitizing the input.
