### PR TITLE
Handle breadcrumbs on POST and PUT requests

### DIFF
--- a/lib/breadcrumbs_on_rails/breadcrumbs.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs.rb
@@ -100,7 +100,8 @@ module BreadcrumbsOnRails
       end
 
       def render_element(element)
-        if @context.request.post? # Force the last breadcrumb to be the active one if the request is a post
+        # Force the last breadcrumb to be the active one if the request is a post or put
+        if @context.request.post? || @context.request.put?
           content = (@elements.last == element) ? element.name : @context.link_to(compute_name(element), compute_path(element))
         else
           content = @context.link_to_unless_current(compute_name(element), compute_path(element))      

--- a/test/unit/simple_builder_test.rb
+++ b/test/unit/simple_builder_test.rb
@@ -12,6 +12,7 @@ class SimpleBuilderTest < ActionView::TestCase
     @template = Template.new
     @request = mock()
     @request.stubs(:post?).returns(false)
+    @request.stubs(:put?).returns(false)    
     @template.stubs(:request).returns(@request)
   end
 
@@ -62,6 +63,12 @@ class SimpleBuilderTest < ActionView::TestCase
   
   def test_render_with_post
     @request.stubs(:post?).returns(true)
+    assert_dom_equal("<a href=\"/element/1\">Element 1</a> &raquo; <a href=\"/element/2\">Element 2</a> &raquo; Element 3",
+                     simplebuilder(@template, generate_elements(3)).render)
+  end
+  
+  def test_render_with_put
+    @request.stubs(:put?).returns(true)
     assert_dom_equal("<a href=\"/element/1\">Element 1</a> &raquo; <a href=\"/element/2\">Element 2</a> &raquo; Element 3",
                      simplebuilder(@template, generate_elements(3)).render)
   end


### PR DESCRIPTION
Modified the simple builder to set the last item to "active" on an HTTP POST request

See https://github.com/weppos/breadcrumbs_on_rails/issues/4 for more details
