### PR TITLE
Fix Rails 3.2 deprecation warning

### DIFF
--- a/lib/breadcrumbs_on_rails/controller_mixin.rb
+++ b/lib/breadcrumbs_on_rails/controller_mixin.rb
@@ -16,7 +16,7 @@ module BreadcrumbsOnRails
       helper          HelperMethods
       helper_method   :add_breadcrumb, :breadcrumbs
     end
-    
+
     protected
 
     def add_breadcrumb(name, path, options = {})


### PR DESCRIPTION
"DEPRECATION WARNING: The InstanceMethods module inside ActiveSupport::Concern will be no longer included automatically. Please define instance methods directly in ActionController::Base instead."

The warning blamed Draper in our case and never mentioned breadcrumbs_on_rails, because Draper loaded ActionController::Base and indirectly triggered this.
