### PR TITLE
Added multi-level breadcrumbs, flags and definers

### DIFF
--- a/breadcrumbs_on_rails.gemspec
+++ b/breadcrumbs_on_rails.gemspec
@@ -9,12 +9,13 @@ Gem::Specification.new do |s|
   s.date = "2012-02-03"
   s.description = "BreadcrumbsOnRails is a simple Ruby on Rails plugin for creating and managing a breadcrumb navigation for a Rails project."
   s.email = "weppos@weppos.net"
-  s.files = [".gitignore", ".travis.yml", "Appraisals", "CHANGELOG.md", "Gemfile", "Gemfile.lock", "LICENSE", "README.md", "Rakefile", "breadcrumbs_on_rails.gemspec", "gemfiles/3.0.gemfile", "gemfiles/3.0.gemfile.lock", "gemfiles/3.1.gemfile", "gemfiles/3.1.gemfile.lock", "gemfiles/3.2.gemfile", "gemfiles/3.2.gemfile.lock", "init.rb", "lib/breadcrumbs_on_rails.rb", "lib/breadcrumbs_on_rails/action_controller.rb", "lib/breadcrumbs_on_rails/breadcrumbs.rb", "lib/breadcrumbs_on_rails/railtie.rb", "lib/breadcrumbs_on_rails/version.rb", "test/test_helper.rb", "test/unit/builder_test.rb", "test/unit/element_test.rb", "test/unit/simple_builder_test.rb"]
   s.homepage = "http://www.simonecarletti.com/code/breadcrumbs_on_rails"
   s.require_paths = ["lib"]
   s.rubygems_version = "1.8.11"
   s.summary = "A simple Ruby on Rails plugin for creating and managing a breadcrumb navigation."
-  s.test_files = ["test/test_helper.rb", "test/unit/builder_test.rb", "test/unit/element_test.rb", "test/unit/simple_builder_test.rb"]
+
+  s.files         = `git ls-files`.split("\n")
+  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
 
   if s.respond_to? :specification_version then
     s.specification_version = 3

--- a/lib/breadcrumbs_on_rails.rb
+++ b/lib/breadcrumbs_on_rails.rb
@@ -10,7 +10,9 @@ require 'breadcrumbs_on_rails/breadcrumbs'
 require 'breadcrumbs_on_rails/version'
 require 'breadcrumbs_on_rails/action_controller'
 require 'breadcrumbs_on_rails/railtie'
-
+require 'breadcrumbs_on_rails/breadcrumbs_methods'
+require 'breadcrumbs_on_rails/breadcrumbs_definer'
+require 'breadcrumbs_on_rails/config'
 
 module BreadcrumbsOnRails
 

--- a/lib/breadcrumbs_on_rails/action_controller.rb
+++ b/lib/breadcrumbs_on_rails/action_controller.rb
@@ -13,19 +13,11 @@ module BreadcrumbsOnRails
 
     included do
       extend          ClassMethods
+      include         InstanceMethods
       helper          HelperMethods
-      helper_method   :add_breadcrumb, :breadcrumbs
+      helper_method   :add_breadcrumb, :breadcrumbs, :flags
     end
 
-    protected
-
-    def add_breadcrumb(name, path, options = {})
-      self.breadcrumbs << Breadcrumbs::Element.new(name, path, options)
-    end
-
-    def breadcrumbs
-      @breadcrumbs ||= []
-    end
 
     module Utils
 
@@ -60,24 +52,192 @@ module BreadcrumbsOnRails
 
     module ClassMethods
 
-      def add_breadcrumb(name, path, filter_options = {})
-        # This isn't really nice here
-        if eval = Utils.convert_to_set_of_strings(filter_options.delete(:eval), %w(name path))
-          name = Utils.instance_proc(name) if eval.include?("name")
-          path = Utils.instance_proc(path) if eval.include?("path")
-        end
+      #
+      # flags methods
+      #
 
+      # get flag value
+      def get_flag(name, filter_options = {})
         before_filter(filter_options) do |controller|
-          controller.send(:add_breadcrumb, name, path)
+          controller.send(:get_flag, name, filter_options)
         end
       end
 
+      # set flag value
+      def set_flag(name, value, filter_options = {})
+        before_filter(filter_options) do |controller|
+          controller.send(:set_flag, name, value, filter_options)
+        end
+      end
+
+      # reset flag value
+      def reset_flag(name, filter_options = {})
+        before_filter(filter_options) do |controller|
+          controller.send(:reset_flag, name, filter_options)
+        end
+      end
+
+      #
+      # breadcrumbs methods
+      #
+
+      # add a breadcrumb
+      def add_breadcrumb(name, path = nil, filter_options = {}, &block)
+        # This isn't really nice here
+        if eval = Utils.convert_to_set_of_strings(filter_options.delete(:eval), %w(name path))
+          name = Utils.instance_proc(name) if eval.include?("name")
+          unless path.nil?
+            path = Utils.instance_proc(path) if eval.include?("path")
+          end
+        end
+
+        before_filter(filter_options) do |controller|
+          # if path isn't defined, use current path
+          path = request.fullpath if path.nil?
+
+          controller.send(:add_breadcrumb, name, path, filter_options, &block)
+        end
+      end
+      alias :add_breadcrumb_for_current :add_breadcrumb
+
+      # define volatile breadcrumbs/flags in a block
+      def definer(name = nil, filter_options = {}, &block)
+        before_filter(filter_options) do |controller|
+          controller.send(:definer, name, filter_options, &block)
+        end
+      end
+    end
+
+    module InstanceMethods
+      protected
+
+      # common
+
+      # getting static,volatile options
+      def static_or_volatile(options)
+        static = options[:static] || false
+        volatile = options[:volatile] || false
+        volatile = (volatile || ((static == false) && (volatile == false)))
+        return static, volatile
+      end
+
+      def definer(name = nil, options = {}, &block)
+        static, volatile = static_or_volatile(options)
+
+        # breadcrumbs
+        if static
+          breadcrumb = static_breadcrumbs(name)
+        else #if volatile
+          breadcrumb = volatile_breadcrumbs(name)
+        end
+        # flags
+        if static
+          flags = static_flags(name)
+        else #if volatile
+          flags = volatile_flags(name)
+        end
+
+        # use a definer to allow block
+        d = BreadcrumbsOnRails::BreadcrumbsDefiner.new(breadcrumb, flags, options)
+        yield d if block_given?
+      end
+
+      # flags
+
+      # get flag value
+      def get_flag(name, options = {})
+        # getting options
+        static, volatile = static_or_volatile(options)
+
+        f = static_flags(options[:flagset]) if static
+        f = volatile_flags(options[:flagset]) if volatile
+        f = flags(options[:flagset]) unless static || volatile
+
+        f[name] if f.include?(name)
+      end
+
+      # reset flag value
+      def reset_flag(name, options = {})
+        set_flag(name, nil, options) unless name.nil?
+      end
+
+      # set flag value
+      def set_flag(name, value = nil, options = {})
+        # getting options
+        static, volatile = static_or_volatile(options)
+
+        # setting flag
+        if static
+          set_static_flag(name, value, options)
+        else #if volatile
+          # default is volatile when nothing's set
+          set_volatile_flag(name, value, options)
+        end
+      end
+
+      # add a static flag, which will be kept for next instances
+      def set_static_flag(name, value, options = {})
+        flagset = options[:flagset]
+        BreadcrumbsOnRails.set_flag_in(static_flags(flagset), name, value, options)
+      end
+
+      # add a volatile flag, only valid in the current instances
+      def set_volatile_flag(name, value, options = {})
+        flagset = options[:flagset]
+        BreadcrumbsOnRails.set_flag_in(volatile_flags(flagset), name, value, options)
+      end
+
+      # return volatile flags defined in the current instance
+      def volatile_flags(flagset = nil)
+        flagset = :default if flagset.nil? 
+        @flags ||= {}
+        @flags[flagset] ||= {}
+        @flags[flagset]
+      end
+      # return static flags defined in the configuration
+      def static_flags(flagset = nil)
+        BreadcrumbsOnRails.static_flags(flagset)
+      end
+      # return all defined flags, static ones first then volatile ones
+      def flags(flagset = nil)
+        static_flags(flagset).merge(volatile_flags(flagset))
+      end
+
+      # add a static breadcrumb, which will be kept for next instances
+      def add_static_breadcrumb(name, path, options = {}, &block)
+        breadcrumb = options[:breadcrumb]
+        BreadcrumbsOnRails.add_breadcrumb_to(static_breadcrumbs(breadcrumb), name, path, options, &block)
+      end
+
+      # add a volatile breadcrumb, only valid in the current instances
+      def add_volatile_breadcrumb(name, path, options = {}, &block)
+        breadcrumb = options[:breadcrumb]
+        BreadcrumbsOnRails.add_breadcrumb_to(volatile_breadcrumbs(breadcrumb), name, path, options, &block)
+      end
+      alias :add_breadcrumb :add_volatile_breadcrumb
+
+      # return volatile breadcrumbs defined in the current instance
+      def volatile_breadcrumbs(breadcrumb = nil)
+        breadcrumb = :default if breadcrumb.nil? 
+        @breadcrumbs ||= {}
+        @breadcrumbs[breadcrumb] ||= []
+      end
+      # return static breadcrumbs defined in the configuration
+      def static_breadcrumbs(breadcrumb = nil)
+        BreadcrumbsOnRails.static_breadcrumbs(breadcrumb)
+      end
+      # return all defined breadcrumbs, static ones first then volatile ones
+      def breadcrumbs(breadcrumb = nil)
+        static_breadcrumbs(breadcrumb) + volatile_breadcrumbs(breadcrumb)
+      end
     end
 
     module HelperMethods
 
       def render_breadcrumbs(options = {}, &block)
-        builder = (options.delete(:builder) || Breadcrumbs::SimpleBuilder).new(self, breadcrumbs, options)
+        # passing all flags to Builder (static + volatile)
+        options[:flags] = flags(options[:breadcrumb])
+        builder = (options.delete(:builder) || Breadcrumbs::SimpleBuilder).new(self, breadcrumbs(options[:breadcrumb]), options)
         content = builder.render.html_safe
         if block_given?
           capture(content, &block)

--- a/lib/breadcrumbs_on_rails/breadcrumbs_definer.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs_definer.rb
@@ -1,0 +1,21 @@
+module BreadcrumbsOnRails
+  # A breadcrumb definer to create breadcrumbs in a block
+  class BreadcrumbsDefiner
+    def initialize(breadcrumb, flags, options = {})
+      @breadcrumb = breadcrumb
+      @flags = flags
+      @options = options
+    end
+
+    # create a new flag in a block
+    def set_flag(name, value = nil, options = {})
+      BreadcrumbsOnRails.set_flag_in(@flags, name, value, options)
+    end
+
+    # create a new breadcrumbs in a block
+    def add_breadcrumb(name, path = nil, options = {}, &block)
+      options[:flag] = name if @options[:flag_for_breadcrumb] == true && name.is_a?(Symbol)
+      BreadcrumbsOnRails.add_breadcrumb_to(@breadcrumb, name, path, options, &block)
+    end
+  end
+end

--- a/lib/breadcrumbs_on_rails/breadcrumbs_methods.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs_methods.rb
@@ -1,0 +1,39 @@
+module BreadcrumbsOnRails
+  # flags
+  def self.static_flags(flagset = nil)
+    flagset = :default if flagset.nil? 
+    @flags ||= {}
+    @flags[flagset] ||= {}
+  end
+
+  # add a new flag to a set of flags
+  def self.set_flag_in(flags, name, value, options = {})
+    flags.merge!({ name => value }) unless name.nil? || value.nil?
+  end
+
+  # create a new breadcrumb element
+  def self.new_breadcrumbs_element(name, path = nil, options = {}, &block)
+    elem = Breadcrumbs::Element.new(name, path, options)
+    yield elem if block_given?
+    return elem
+  end
+
+  # add a new breadcrumb element to a set of breadcrumbs
+  def self.add_breadcrumb_to(breadcrumb, name, path, options = {}, &block)
+    breadcrumb << new_breadcrumbs_element(name, path, options, &block)
+  end
+
+  # breadcrumbs
+  def self.add_breadcrumb(name, path, options = {}, &block)
+    breadcrumb = options[:breadcrumb]
+    add_breadcrumb_to(static_breadcrumbs(breadcrumb), name, path, options, &block)
+  end
+
+  # return static breadcrumbs
+  def self.static_breadcrumbs(breadcrumb = nil)
+    breadcrumb = :default if breadcrumb.nil? 
+    @breadcrumbs ||= {}
+    @breadcrumbs[breadcrumb] ||= []
+  end
+end
+

--- a/lib/breadcrumbs_on_rails/config.rb
+++ b/lib/breadcrumbs_on_rails/config.rb
@@ -1,0 +1,44 @@
+require 'active_support/configurable'
+
+module BreadcrumbsOnRails
+  # Configures global settings for BreadcrumbsOnRails
+  def self.configure(&block)
+    yield @config ||= BreadcrumbsOnRails::Configuration.new
+  end
+
+  # Global settings for BreadcrumbsOnRails
+  def self.config
+    @config
+  end
+
+  # need a Class for 3.0
+  class Configuration #:nodoc:
+    include ActiveSupport::Configurable
+    config_accessor :breadcrumbs
+    config_accessor :flags
+
+    # common
+    def definer(name = nil, options = {}, &block)
+      # breadcrumbs
+      breadcrumb = BreadcrumbsOnRails.static_breadcrumbs(name)
+      # flags
+      flags = BreadcrumbsOnRails.static_flags(name)
+
+      # use a definer to allow block
+      d = BreadcrumbsDefiner.new(breadcrumb, flags, options)
+      yield d if block_given?
+    end
+
+    # create a new static flag in the configuration
+    def set_flag(name, value = nil, options = {})
+      flags = BreadcrumbsOnRails.static_flags(options[:flagset])
+      BreadcrumbsOnRails.set_flag_in(flags, name, value, options)
+    end
+
+    # create a new static breadcrumbs in the configuration
+    def add_breadcrumb(name, path = nil, options = {}, &block)
+      breadcrumb = BreadcrumbsOnRails.static_breadcrumbs(options[:breadcrumb])
+      BreadcrumbsOnRails.add_breadcrumb_to(breadcrumb, name, path, options, &block)
+    end
+  end
+end

--- a/lib/breadcrumbs_on_rails/railtie.rb
+++ b/lib/breadcrumbs_on_rails/railtie.rb
@@ -10,10 +10,11 @@ module BreadcrumbsOnRails
 
   class Railtie < Rails::Railtie
     initializer "breadcrumbs_on_rails.initialize" do
-      ActiveSupport.on_load(:action_controller) do
-        include BreadcrumbsOnRails::ActionController
-      end
     end
   end
 
+end
+
+ActiveSupport.on_load(:action_controller) do
+  include BreadcrumbsOnRails::ActionController
 end

--- a/test/dummy.rb
+++ b/test/dummy.rb
@@ -1,0 +1,42 @@
+ENV["RAILS_ENV"] = "test"
+
+require "active_support"
+require "action_controller"
+require "rails/railtie"
+
+class Dummy
+  Routes = ActionDispatch::Routing::RouteSet.new
+  Routes.draw do
+    match ':controller(/:action(/:id))'
+  end
+end
+
+ActionController::Base.view_paths = File.join(File.dirname(__FILE__), 'views')
+ActionController::Base.send :include, Dummy::Routes.url_helpers
+
+class ActiveSupport::TestCase
+
+  setup do
+    @routes = Dummy::Routes
+  end
+
+
+  def controller
+    @controller_proxy ||= ControllerProxy.new(@controller)
+  end
+
+  class ControllerProxy
+    def initialize(controller)
+      @controller = controller
+    end
+    def method_missing(method, *args)
+      @controller.instance_eval do
+        m = method(method)
+        m.call(*args)
+      end
+    end
+  end
+
+end
+
+

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,20 +1,11 @@
 require 'test/unit'
 require 'mocha'
+require 'dummy'
 
 ENV["RAILS_ENV"] = "test"
 
-require "active_support"
-require "action_controller"
-require "rails/railtie"
 
 $:.unshift File.expand_path('../../lib', __FILE__)
 require 'breadcrumbs_on_rails'
 
 ActionController::Base.view_paths = File.join(File.dirname(__FILE__), 'views')
-
-BreadcrumbsOnRails::Routes = ActionDispatch::Routing::RouteSet.new
-BreadcrumbsOnRails::Routes.draw do
-  match ':controller(/:action(/:id))'
-end
-
-ActionController::Base.send :include, BreadcrumbsOnRails::Routes.url_helpers

--- a/test/unit/action_controller_test.rb
+++ b/test/unit/action_controller_test.rb
@@ -1,0 +1,108 @@
+require 'test_helper'
+
+BreadcrumbsOnRails.configure do |config|
+  config.add_breadcrumb :static_breadcrumb, :root_path
+  config.add_breadcrumb :static_breadcrumb_bis, :root_path, :breadcrumb => :default
+
+  config.definer :user_menu, :flag_for_breadcrumb => true do |d|
+    d.add_breadcrumb :home, :root_path
+    d.add_breadcrumb :users, :users_path, :flag => :users do |breadcrumb|
+      breadcrumb.add_breadcrumb :dashboard, :dashboard_users_path
+      breadcrumb.add_breadcrumb :help, :help_users_path
+    end
+    
+    d.set_flag :home, true
+    d.set_flag :users, false
+  end
+
+end
+
+
+class BreadcrumbsTestController < ActionController::Base
+  add_breadcrumb :root, :extranet_root_path
+  add_breadcrumb :footab, :root_path
+  add_breadcrumb_for_current :current_page 
+
+  set_flag :foo, true
+  set_flag :bar, false
+
+  definer :user_menu, :flag_for_breadcrumb => true do |d|
+    d.add_breadcrumb :dashboard, :root_path
+    d.add_breadcrumb :main_screen, :root_path
+
+    d.set_flag :dashboard, false
+    d.set_flag :dashboard_icon, :none
+    d.set_flag :main_screen_value, 2
+  end
+
+
+  def index
+    render :text => ''
+  end
+
+  def show
+    set_flag :bar, true
+    render :text => ''
+  end
+end
+
+class BreadcrumbsTest < ActionController::TestCase
+  tests BreadcrumbsTestController
+
+  def test_add_volatile_breadcrumb
+    get :index
+    assert_equal(:root, controller.volatile_breadcrumbs(:default).first.name)
+  end
+
+  def test_add_breadcrumb_for_current
+    get :show
+    assert_equal('/breadcrumbs_test/show', controller.volatile_breadcrumbs(:default).last.path)
+  end
+
+  def test_add_static_breadcrumb
+    get :index
+    assert_equal(:static_breadcrumb, controller.breadcrumbs(:default).first.name)
+  end
+
+  def test_static_and_volatile_breadcrumbs
+    get :index
+    assert_equal(5, controller.breadcrumbs(:default).count)
+  end
+
+  def test_set_volatile_flag
+    get :index
+    assert_equal(true, controller.flags(:default)[:foo])
+  end
+
+  def test_set_static_flag
+    get :index
+    assert_equal(true, controller.flags(:user_menu)[:home])
+  end
+
+  def test_static_and_volatile_flags
+    get :index
+    assert_equal(5, controller.flags(:user_menu).count)
+  end
+
+  def test_set_flag_within_method
+    get :show
+    assert_equal(true, controller.flags(:default)[:bar])
+  end
+
+  def test_add_breadcrumb_with_definer
+    get :index
+    assert_equal(:main_screen, controller.breadcrumbs(:user_menu).last.name)
+  end
+
+  def test_definer_with_flag_for_breadcrumb_set
+    get :index
+    assert_equal(:main_screen, controller.breadcrumbs(:user_menu).last.options[:flag])
+  end
+
+  def test_set_flag_with_definer
+    get :index
+    assert_equal(:none, controller.flags(:user_menu)[:dashboard_icon])
+  end
+
+end
+

--- a/test/unit/builder_test.rb
+++ b/test/unit/builder_test.rb
@@ -78,7 +78,19 @@ class BuilderTest < ActionView::TestCase
     assert_equal("http://localhost/#string", builder.send(:compute_path, element))
   end
 
+  def test_empty_associated_flagset
+    builder = BreadcrumbsOnRails::Breadcrumbs::Builder.new(@template, [])
+    element = BreadcrumbsOnRails::Breadcrumbs::Element.new(nil, "http://localhost/")
 
+    assert_equal(nil, builder.send(:flag_for, element))
+  end
+
+  def test_associated_flagset
+    builder = BreadcrumbsOnRails::Breadcrumbs::Builder.new(@template, [], :flags => {:activated => true, :seen => 5})
+    element = BreadcrumbsOnRails::Breadcrumbs::Element.new(nil, "http://localhost/", :flag => :activated)
+
+    assert_equal(true, builder.send(:flag_for, element, :flag))
+  end
 
   def url_for(params)
     "http://localhost?" + params.to_param

--- a/test/unit/element_test.rb
+++ b/test/unit/element_test.rb
@@ -23,6 +23,13 @@ class ElementTest < ActiveSupport::TestCase
     assert_equal({ :title => "Go to the Homepage" }, element.options)
   end
 
+  def test_initialize_should_allow_childs
+    element = BreadcrumbsOnRails::Breadcrumbs::Element.new(:homepage, "/", :title => "Go to the Homepage")
+    element.add_child(nil, '/')
+    element.add_child(:homepage, nil)
+    assert_equal(2, element.childs.count)
+  end
+
 
   def test_name
     element = BreadcrumbsOnRails::Breadcrumbs::Element.new(nil, nil)


### PR DESCRIPTION
Hi Simone,

I've added some new features to your gem :
- multi-level breadcrumbs (to add alternate breadcrumbs)
- multiple breadcrumbs, to have different breadcrumbs/menus displayed at one time
- static breadcrumbs to create static menus to be defined at one place
- flags to interact with menus and activate or toggle highlights for example
- definer method, to define the whole menu/breadcrumb in one block
- documentation in readme file to create new builders and to use all the features

Thomas
