### PR TITLE
Update lib/breadcrumbs_on_rails/breadcrumbs.rb

### DIFF
--- a/lib/breadcrumbs_on_rails/breadcrumbs.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs.rb
@@ -87,7 +87,7 @@ module BreadcrumbsOnRails
       end
 
       def render_element(element)
-        content = @context.link_to_unless_current(compute_name(element), compute_path(element), element.options)
+        content = ( compute_path(element).blank? ? compute_name(element) : @context.link_to_unless_current(compute_name(element), compute_path(element), element.options) )
         if @options[:tag]
           @context.content_tag(@options[:tag], content)
         else


### PR DESCRIPTION
if path is nil don't attempt to make breadcrumb a url
otherwise business as usual
