### PR TITLE
 Extract SimpleBuilder to a separate file

### DIFF
--- a/lib/breadcrumbs_on_rails.rb
+++ b/lib/breadcrumbs_on_rails.rb
@@ -10,6 +10,7 @@ require 'breadcrumbs_on_rails/breadcrumbs'
 require 'breadcrumbs_on_rails/version'
 require 'breadcrumbs_on_rails/action_controller'
 require 'breadcrumbs_on_rails/railtie'
+require 'breadcrumbs_on_rails/breadcrumbs/simple_builder'
 
 
 module BreadcrumbsOnRails

--- a/lib/breadcrumbs_on_rails/breadcrumbs.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs.rb
@@ -69,37 +69,6 @@ module BreadcrumbsOnRails
     end
 
 
-    # The SimpleBuilder is the default breadcrumb builder.
-    # It provides basic functionalities to render a breadcrumb navigation.
-    #
-    # The SimpleBuilder accepts a limited set of options.
-    # If you need more flexibility, create a custom Builder and
-    # pass the option :builder => BuilderClass to the <tt>render_breadcrumbs</tt> helper method.
-    #
-    class SimpleBuilder < Builder
-
-      def render
-        @elements.collect do |element|
-          render_element(element)
-        end.join(@options[:separator] || " &raquo; ")
-      end
-
-      def render_element(element)
-        if element.path == nil
-          content = compute_name(element)
-        else
-          content = @context.link_to_unless_current(compute_name(element), compute_path(element), element.options)
-        end
-        if @options[:tag]
-          @context.content_tag(@options[:tag], content)
-        else
-          content
-        end
-      end
-
-    end
-
-
     # Represents a navigation element in the breadcrumb collection.
     #
     class Element

--- a/lib/breadcrumbs_on_rails/breadcrumbs/simple_builder.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs/simple_builder.rb
@@ -1,0 +1,45 @@
+#--
+# Breadcrumbs On Rails
+#
+# A simple Ruby on Rails plugin for creating and managing a breadcrumb navigation.
+#
+# Copyright (c) 2009-2012 Simone Carletti <weppos@weppos.net>
+#++
+
+module BreadcrumbsOnRails
+
+  module Breadcrumbs
+
+    # The SimpleBuilder is the default breadcrumb builder.
+    # It provides basic functionalities to render a breadcrumb navigation.
+    #
+    # The SimpleBuilder accepts a limited set of options.
+    # If you need more flexibility, create a custom Builder and
+    # pass the option :builder => BuilderClass to the <tt>render_breadcrumbs</tt> helper method.
+    #
+    class SimpleBuilder < Builder
+
+      def render
+        @elements.collect do |element|
+          render_element(element)
+        end.join(@options[:separator] || " &raquo; ")
+      end
+
+      def render_element(element)
+        if element.path == nil
+          content = compute_name(element)
+        else
+          content = @context.link_to_unless_current(compute_name(element), compute_path(element), element.options)
+        end
+        if @options[:tag]
+          @context.content_tag(@options[:tag], content)
+        else
+          content
+        end
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
#23 was closed but I think it's right that builders (there is one now - `SimpleBuilder`)

should be in separate files.
- Number of builders may be more than one;
- `SimpleBuilder` is just an instance (an example) of a builder.
  It's a standard way but it's not a class to inherit. It's just a one of the ways.
- `SimpleBuilder` has own test file but doesn't have own code file.
