### PR TITLE
"config" object for setting defaults

### DIFF
--- a/lib/breadcrumbs_on_rails/action_controller.rb
+++ b/lib/breadcrumbs_on_rails/action_controller.rb
@@ -77,8 +77,14 @@ module BreadcrumbsOnRails
     module HelperMethods
 
       def render_breadcrumbs(options = {}, &block)
-        builder = (options.delete(:builder) || Breadcrumbs::SimpleBuilder).new(self, breadcrumbs, options)
+        builder = (
+          options.delete(:builder) || 
+          Breadcrumbs::config.builder ||
+          Breadcrumbs::SimpleBuilder
+        ).new(self, breadcrumbs, options)
+        
         content = builder.render.html_safe
+        
         if block_given?
           capture(content, &block)
         else

--- a/lib/breadcrumbs_on_rails/breadcrumbs.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs.rb
@@ -1,3 +1,5 @@
+require 'ostruct'
+
 #--
 # Breadcrumbs On Rails
 #

--- a/lib/breadcrumbs_on_rails/breadcrumbs.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs.rb
@@ -9,6 +9,10 @@
 module BreadcrumbsOnRails
 
   module Breadcrumbs
+    
+    def self.config 
+      @config ||= OpenStruct.new 
+    end
 
     # The Builder class represents the abstract class for any custom Builder.
     #
@@ -81,7 +85,7 @@ module BreadcrumbsOnRails
       def render
         @elements.collect do |element|
           render_element(element)
-        end.join(@options[:separator] || " &raquo; ")
+        end.join(@options[:separator] || Breadcrumbs::config.separator || " &raquo; ")
       end
 
       def render_element(element)
@@ -90,8 +94,8 @@ module BreadcrumbsOnRails
         else
           content = @context.link_to_unless_current(compute_name(element), compute_path(element), element.options)
         end
-        if @options[:tag]
-          @context.content_tag(@options[:tag], content)
+        if @options[:tag] || Breadcrumbs::config.tag
+          @context.content_tag((@options[:tag] || Breadcrumbs::config.tag), content)
         else
           content
         end


### PR DESCRIPTION
I was using breadcrumbs_on_rails along with a twitter bootstrap-friendly builder (https://gist.github.com/riyad/1933884) and it felt tedious and wrong explicitly passing the "builder" and "separator" options to every "render_breadcrumbs" invocation when these things weren't changing, so I added a Breadcrumbs "config" module member (and supporting logic to the view helpers and SimpleBuilder) so that I could just stick this in an initializer:

```
# config/initializers/breadcrumbs_on_rails.rb
BreadcrumbsOnRails::Breadcrumbs::config.builder = ::BootstrapBreadcrumbsBuilder
BreadcrumbsOnRails::Breadcrumbs::config.separator = "&raquo;"    
```

Merge if you see fit.
