### PR TITLE
Add `safe` option for `add_breadcrumb` method

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,7 +29,7 @@ spec = Gem::Specification.new do |s|
 
   s.add_development_dependency "rails", ">= 3.0"
   s.add_development_dependency "appraisal"
-  s.add_development_dependency "mocha", "~> 0.9.10"
+  s.add_development_dependency "mocha", "~> 0.13.3"
   s.add_development_dependency "yard"
 end
 

--- a/breadcrumbs_on_rails.gemspec
+++ b/breadcrumbs_on_rails.gemspec
@@ -22,18 +22,18 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_development_dependency(%q<rails>, [">= 3.0"])
       s.add_development_dependency(%q<appraisal>, [">= 0"])
-      s.add_development_dependency(%q<mocha>, ["~> 0.9.10"])
+      s.add_development_dependency(%q<mocha>, ["~> 0.13.3"])
       s.add_development_dependency(%q<yard>, [">= 0"])
     else
       s.add_dependency(%q<rails>, [">= 3.0"])
       s.add_dependency(%q<appraisal>, [">= 0"])
-      s.add_dependency(%q<mocha>, ["~> 0.9.10"])
+      s.add_dependency(%q<mocha>, ["~> 0.13.3"])
       s.add_dependency(%q<yard>, [">= 0"])
     end
   else
     s.add_dependency(%q<rails>, [">= 3.0"])
     s.add_dependency(%q<appraisal>, [">= 0"])
-    s.add_dependency(%q<mocha>, ["~> 0.9.10"])
+    s.add_dependency(%q<mocha>, ["~> 0.13.3"])
     s.add_dependency(%q<yard>, [">= 0"])
   end
 end

--- a/lib/breadcrumbs_on_rails/breadcrumbs.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs.rb
@@ -51,7 +51,11 @@ module BreadcrumbsOnRails
           when Proc
             name.call(@context)
           else
-            name.to_s
+            if element.safe
+              name.html_safe
+            else
+              ERB::Util.h(name)
+            end
           end
         end
 
@@ -110,17 +114,20 @@ module BreadcrumbsOnRails
       attr_accessor :path
       # @return [Hash] The element/link URL.
       attr_accessor :options
+      # @return [Boolean] The element's safety
+      attr_accessor :safe
 
       # Initializes the Element with given parameters.
       #
       # @param  [String] name The element/link name.
       # @param  [String] path The element/link URL.
-      # @param  [Hash] options The element/link URL.
+      # @param  [Hash] options for element/link URL and name's safety
       # @return [Element]
       #
       def initialize(name, path = nil, options = {})
         self.name     = name
         self.path     = path
+        self.safe     = options.delete(:safe)
         self.options  = options
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,5 @@
 require 'test/unit'
-require 'mocha'
+require 'mocha/setup'
 require 'dummy'
 
 $:.unshift File.expand_path('../../lib', __FILE__)

--- a/test/unit/action_controller_test.rb
+++ b/test/unit/action_controller_test.rb
@@ -20,6 +20,16 @@ class ExampleController < ActionController::Base
     execute("action_default")
   end
 
+  def action_unsafe_names
+    add_breadcrumb "<strong>Hello</strong>", "/"
+    execute("action_default")
+  end
+
+  def action_safe_names
+    add_breadcrumb "<strong>Hello</strong>", "/", :safe => true
+    execute("action_default")
+  end
+
 
   private
 
@@ -48,6 +58,18 @@ class ExampleControllerTest < ActionController::TestCase
   def test_render_compute_paths
     get :action_compute_paths
     assert_dom_equal  %(<a href="/">String</a> &raquo; <a href="/?proc">Proc</a> &raquo; <a href="/?polymorfic">Polymorfic</a>),
+                      @response.body
+  end
+
+  def test_action_unsafe_names
+    get :action_unsafe_names
+    assert_dom_equal  %(<a href="/">&lt;strong&gt;Hello&lt;/strong&gt;</a>),
+                      @response.body
+  end
+
+  def test_action_safe_names
+    get :action_safe_names
+    assert_dom_equal  %(<a href="/"><strong>Hello</strong></a>),
                       @response.body
   end
 


### PR DESCRIPTION
In case, when somebody wants to pass HTML for breadcrumb title, that person should use `safe: true` option

Example:
```ruby
add_breadcrumb '<i icon="museum-icon"></i> Museum', '/somewhere', safe: true
```