### PR TITLE
Bug fixing - param "title" doesn't appear in an anchor

### DIFF
--- a/lib/breadcrumbs_on_rails/action_controller.rb
+++ b/lib/breadcrumbs_on_rails/action_controller.rb
@@ -68,7 +68,7 @@ module BreadcrumbsOnRails
         end
 
         before_filter(filter_options) do |controller|
-          controller.send(:add_breadcrumb, name, path)
+          controller.send(:add_breadcrumb, name, path, filter_options)
         end
       end
 


### PR DESCRIPTION
Now param "title" is shown in an anchor like that: `<a title"...">...</>`
