### PR TITLE
Fix for missing options on class level add_breadcrumbs method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ In your controller, call `add_breadcrumb` to push a new element on the breadcrum
 The third, optional argument is a Hash of options to customize the breadcrumb link.
 
     class MyController
+      add_breadcrumb "home", :root_path, :options => { :title => "Home" }
+
       def index
         add_breadcrumb "index", index_path, :title => "Back to the Index"
       end

--- a/lib/breadcrumbs_on_rails/action_controller.rb
+++ b/lib/breadcrumbs_on_rails/action_controller.rb
@@ -67,8 +67,10 @@ module BreadcrumbsOnRails
           path = Utils.instance_proc(path) if eval.include?("path")
         end
 
+        element_options = filter_options.delete(:options) || {}
+
         before_filter(filter_options) do |controller|
-          controller.send(:add_breadcrumb, name, path)
+          controller.send(:add_breadcrumb, name, path, element_options)
         end
       end
 

--- a/test/unit/action_controller_test.rb
+++ b/test/unit/action_controller_test.rb
@@ -16,7 +16,7 @@ class ExampleController < ActionController::Base
   def action_compute_paths
     add_breadcrumb "String", "/"
     add_breadcrumb "Proc", proc { |c| "/?proc" }
-    add_breadcrumb "Polymorfic", [:admin, :namespace]
+    add_breadcrumb "Polymorphic", [:admin, :namespace]
     execute("action_default")
   end
 
@@ -30,7 +30,7 @@ class ExampleController < ActionController::Base
   end
 
   def admin_namespace_path(*)
-    "/?polymorfic"
+    "/?polymorphic"
   end
   helper_method :admin_namespace_path
 
@@ -47,8 +47,45 @@ class ExampleControllerTest < ActionController::TestCase
 
   def test_render_compute_paths
     get :action_compute_paths
-    assert_dom_equal  %(<a href="/">String</a> &raquo; <a href="/?proc">Proc</a> &raquo; <a href="/?polymorfic">Polymorfic</a>),
+    assert_dom_equal  %(<a href="/">String</a> &raquo; <a href="/?proc">Proc</a> &raquo; <a href="/?polymorphic">Polymorphic</a>),
                       @response.body
+  end
+
+end
+
+class ClassLevelExampleController < ActionController::Base
+  include BreadcrumbsOnRails::ActionController
+
+  add_breadcrumb "String", "/"
+  add_breadcrumb "Proc", proc { |c| "/?proc" }
+  add_breadcrumb "Polymorphic", [:admin, :namespace]
+  add_breadcrumb "With options", "/", :options => { :title => "Awesome" }
+
+  def action_default
+    render 'example/default'
+  end
+
+  private
+
+  def admin_namespace_path(*)
+    "/?polymorphic"
+  end
+  helper_method :admin_namespace_path
+
+end
+
+class ClassLevelExampleControllerTest < ActionController::TestCase
+
+  def test_render_default
+    expected = [].tap { |links|
+      links << "<a href=\"/\">String</a>"
+      links << "<a href=\"/?proc\">Proc</a>"
+      links << "<a href=\"/?polymorphic\">Polymorphic</a>"
+      links << "<a href=\"/\" title=\"Awesome\">With options</a>"
+    }
+
+    get :action_default
+    assert_dom_equal %(#{expected.join(" &raquo; ")}), @response.body
   end
 
 end


### PR DESCRIPTION
The class level `add_breadcrumbs` method doesn't allow element options to be passed through - instead it captures all options as before_filter options.

This change allows you to put an options hash strictly for element options into the options hash, and strips it out so that the before_filter options are passed to the before_filter, and the element options are passed to the breadcrumb creator method.
