### PR TITLE
fix name collision

### DIFF
--- a/lib/breadcrumbs_on_rails/action_controller.rb
+++ b/lib/breadcrumbs_on_rails/action_controller.rb
@@ -14,18 +14,20 @@ module BreadcrumbsOnRails
     included do
       extend          ClassMethods
       helper          HelperMethods
-      helper_method   :add_breadcrumb, :breadcrumbs
+      helper_method   :add_breadcrumb, :breadcrumbs_collection
     end
 
     protected
 
     def add_breadcrumb(name, path = nil, options = {})
-      self.breadcrumbs << Breadcrumbs::Element.new(name, path, options)
+      self.breadcrumbs_collection << Breadcrumbs::Element.new(name, path, options)
     end
 
     def breadcrumbs
       @breadcrumbs ||= []
     end
+    alias_method :breadcrumbs_collection, :breadcrumbs
+
 
     module Utils
 
@@ -79,7 +81,7 @@ module BreadcrumbsOnRails
     module HelperMethods
 
       def render_breadcrumbs(options = {}, &block)
-        builder = (options.delete(:builder) || Breadcrumbs::SimpleBuilder).new(self, breadcrumbs, options)
+        builder = (options.delete(:builder) || Breadcrumbs::SimpleBuilder).new(self, breadcrumbs_collection, options)
         content = builder.render.html_safe
         if block_given?
           capture(content, &block)


### PR DESCRIPTION
the method breadcrumbs is too common, i use Spree(https://github.com/spree/spree) and it overrides the method "breadcrumbs", so this is suggestion to solve this kind of issues.