### PR TITLE
Fix a typo

### DIFF
--- a/lib/breadcrumbs_on_rails/action_controller.rb
+++ b/lib/breadcrumbs_on_rails/action_controller.rb
@@ -37,7 +37,7 @@ module BreadcrumbsOnRails
         end
       end
 
-      # This is an horrible method with an horrible name.
+      # This is a horrible method with a horrible name.
       #
       #   convert_to_set_of_strings(nil, [:foo, :bar])
       #   # => nil


### PR DESCRIPTION
It should be "a horrible", not "an horrible". There are some examples: http://www.merriam-webster.com/dictionary/horrible .
