### PR TITLE
Escape user input

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 - Rails 3 or Rails 4
 
-Please note 
+Please note
 
 - <tt>BreadcrumbsOnRails</tt> 2.x requires Rails 3. Use <tt>BreadcrumbsOnRails</tt> 1.x with Rails 2.
 - <tt>BreadcrumbsOnRails</tt> doesn't work with Rails 2.1 or lower.
@@ -33,16 +33,16 @@ Creating a breadcrumb navigation menu in your Rails app using <tt>BreadcrumbsOnR
 In your controller, call `add_breadcrumb` to push a new element on the breadcrumb stack. `add_breadcrumb` requires two arguments: the name of the breadcrumb and the target path.
 
     class MyController
-    
+
       add_breadcrumb "home", :root_path
       add_breadcrumb "my", :my_path
-      
+
       def index
         # ...
-        
+
         add_breadcrumb "index", index_path
       end
-    
+
     end
 
 The third, optional argument is a Hash of options to customize the breadcrumb link.
@@ -55,6 +55,19 @@ The third, optional argument is a Hash of options to customize the breadcrumb li
       end
     end
 
+The text of the breadcrumb will be html-escaped unless it is a SafeBuffer to prevent XSS attacks.
+
+    class MyController
+      add_breadcrumb "This is the <b>Main</b> page".html_safe
+
+      def profile
+        add_breadcrumb "#{@user_name} Profile", users_profile
+      end
+    end
+
+    In this case, if @user_name is "<script>", it will output:
+      This is the <b>Main</b> page > &lt;script&gt; Profile
+
 In your view, you can render the breadcrumb menu with the `render_breadcrumbs` helper.
 
     <!DOCTYPE html>
@@ -62,7 +75,7 @@ In your view, you can render the breadcrumb menu with the `render_breadcrumbs` h
     <head>
       <title>untitled</title>
     </head>
-    
+
     <body>
       <%= render_breadcrumbs %>
     </body>

--- a/lib/breadcrumbs_on_rails/breadcrumbs.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs.rb
@@ -93,7 +93,7 @@ module BreadcrumbsOnRails
         if @options[:tag]
           @context.content_tag(@options[:tag], content)
         else
-          content
+          "".html_safe + content
         end
       end
 

--- a/lib/breadcrumbs_on_rails/breadcrumbs.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs.rb
@@ -93,7 +93,7 @@ module BreadcrumbsOnRails
         if @options[:tag]
           @context.content_tag(@options[:tag], content)
         else
-          "".html_safe + content
+          ERB::Util.h(content)
         end
       end
 

--- a/test/unit/simple_builder_test.rb
+++ b/test/unit/simple_builder_test.rb
@@ -66,6 +66,23 @@ class SimpleBuilderTest < ActionView::TestCase
                      simplebuilder(@template, elements).render)
   end
 
+  def test_render_with_embedded_html_and_tags
+    elements = [BreadcrumbsOnRails::Breadcrumbs::Element.new("Element <b>One</b>", nil)]
+    assert_dom_equal("<li>Element &lt;b&gt;One&lt;/b&gt;</li>",
+                     simplebuilder(@template, elements, {tag: :li} ).render)
+  end
+
+  def test_render_with_safe_embedded_html
+    elements = [BreadcrumbsOnRails::Breadcrumbs::Element.new("Element <b>One</b>".html_safe, nil)]
+    assert_dom_equal("Element <b>One</b>",
+                     simplebuilder(@template, elements).render)
+  end
+
+  def test_render_with_embedded_html_and_tags
+    elements = [BreadcrumbsOnRails::Breadcrumbs::Element.new("Element <b>One</b>".html_safe, nil)]
+    assert_dom_equal("<li>Element <b>One</b></li>",
+                     simplebuilder(@template, elements, {tag: :li} ).render)
+  end
 
   protected
 

--- a/test/unit/simple_builder_test.rb
+++ b/test/unit/simple_builder_test.rb
@@ -60,6 +60,12 @@ class SimpleBuilderTest < ActionView::TestCase
                      simplebuilder(@template, elements).render)
   end
 
+  def test_render_with_embedded_html
+    elements = [BreadcrumbsOnRails::Breadcrumbs::Element.new("Element <b>One</b>", nil)]
+    assert_dom_equal("Element &lt;b&gt;One&lt;/b&gt;",
+                     simplebuilder(@template, elements).render)
+  end
+
 
   protected
 


### PR DESCRIPTION
This change causes all breadcrumb text to be untrusted by default (unless it's a SafeBuffer).

This resolves PR #42, but in a different way instead of passing a new option, it allows you to pass a SafeBuffer.

This is necessary to prevent XSS attacks when adding user-supplied input in the breadcrumb.