### PR TITLE
Register on_load before any initializers run

### DIFF
--- a/lib/breadcrumbs_on_rails/railtie.rb
+++ b/lib/breadcrumbs_on_rails/railtie.rb
@@ -9,7 +9,7 @@
 module BreadcrumbsOnRails
 
   class Railtie < Rails::Railtie
-    initializer "breadcrumbs_on_rails.initialize" do
+    config.before_configuration do
       ActiveSupport.on_load(:action_controller) do
         include BreadcrumbsOnRails::ActionController
       end


### PR DESCRIPTION
The default behavior of `initialize` is to register that block to run after the last initializer to be registered.
When breadcrumbs_on_rails' initializer runs after an initializer where `ActionController` has already been
loaded, that prevents `BreadcrumbsOnRails::ActionController` from ever getting included.

This is particularly apparent when another gem's railtie registers its initializer to run very late, such as
using `:after => :load_config_initializers` and that railtie is loaded before this one because of the order of
gems in a Gemfile.

By using `config.before_configuration` this block will run before any initializers, and should be less
susceptible to railtie ordering problems.