### PR TITLE
added prepend and append options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 pkg/*
 Gemfile.lock
 gemfiles/*.gemfile.lock
+.idea/*
 
 # YARD
 .yardoc

--- a/lib/breadcrumbs_on_rails/action_controller.rb
+++ b/lib/breadcrumbs_on_rails/action_controller.rb
@@ -20,8 +20,6 @@ module BreadcrumbsOnRails
     protected
 
     def add_breadcrumb(name, path = nil, options = {})
-      p "add_breadcrumb"
-      p options
       self.breadcrumbs << Breadcrumbs::Element.new(name, path, options)
     end
 
@@ -63,23 +61,13 @@ module BreadcrumbsOnRails
     module ClassMethods
 
       def add_breadcrumb(name, path = nil, filter_options = {})
-        p "filter_options"
-        p filter_options
         # This isn't really nice here
         if eval = Utils.convert_to_set_of_strings(filter_options.delete(:eval), %w(name path))
           name = Utils.instance_proc(name) if eval.include?("name")
           path = Utils.instance_proc(path) if eval.include?("path")
         end
 
-
-        append_prepend_options = filter_options.slice(:append, :prepend)
-        p "append_prepend_options"
-        p append_prepend_options
-
         element_options = filter_options.delete(:options) || {}
-
-        p "append_prepend_options merge"
-        p element_options.merge!(append_prepend_options)
 
         before_filter(filter_options) do |controller|
           controller.send(:add_breadcrumb, name, path, element_options)
@@ -91,8 +79,6 @@ module BreadcrumbsOnRails
     module HelperMethods
 
       def render_breadcrumbs(options = {}, &block)
-        p "render_breadcrumbs options"
-        p options
         builder = (options.delete(:builder) || Breadcrumbs::SimpleBuilder).new(self, breadcrumbs, options)
         content = builder.render.html_safe
         if block_given?

--- a/lib/breadcrumbs_on_rails/action_controller.rb
+++ b/lib/breadcrumbs_on_rails/action_controller.rb
@@ -72,7 +72,7 @@ module BreadcrumbsOnRails
         end
 
 
-        append_prepend_options = filter_options[:options].slice(:append, :prepend)
+        append_prepend_options = filter_options.slice(:append, :prepend)
         p "append_prepend_options"
         p append_prepend_options
 

--- a/lib/breadcrumbs_on_rails/action_controller.rb
+++ b/lib/breadcrumbs_on_rails/action_controller.rb
@@ -71,7 +71,13 @@ module BreadcrumbsOnRails
 
 
         append_prepend_options = filter_options[:options].slice(:append, :prepend)
+        p "append_prepend_options"
+        p append_prepend_options
+
         element_options = filter_options.delete(:options) || {}
+
+        p "element_options.merge!(append_prepend_options)"
+        p element_options.merge!(append_prepend_options)
 
         before_filter(filter_options) do |controller|
           controller.send(:add_breadcrumb, name, path, element_options.merge!(append_prepend_options))

--- a/lib/breadcrumbs_on_rails/action_controller.rb
+++ b/lib/breadcrumbs_on_rails/action_controller.rb
@@ -20,6 +20,8 @@ module BreadcrumbsOnRails
     protected
 
     def add_breadcrumb(name, path = nil, options = {})
+      p "add_breadcrumb"
+      p options
       self.breadcrumbs << Breadcrumbs::Element.new(name, path, options)
     end
 
@@ -61,13 +63,23 @@ module BreadcrumbsOnRails
     module ClassMethods
 
       def add_breadcrumb(name, path = nil, filter_options = {})
+        p "filter_options"
+        p filter_options
         # This isn't really nice here
         if eval = Utils.convert_to_set_of_strings(filter_options.delete(:eval), %w(name path))
           name = Utils.instance_proc(name) if eval.include?("name")
           path = Utils.instance_proc(path) if eval.include?("path")
         end
 
+
+        append_prepend_options = filter_options.slice(:append, :prepend)
+        p "append_prepend_options"
+        p append_prepend_options
+
         element_options = filter_options.delete(:options) || {}
+
+        p "append_prepend_options merge"
+        p element_options.merge!(append_prepend_options)
 
         before_filter(filter_options) do |controller|
           controller.send(:add_breadcrumb, name, path, element_options)
@@ -79,6 +91,8 @@ module BreadcrumbsOnRails
     module HelperMethods
 
       def render_breadcrumbs(options = {}, &block)
+        p "render_breadcrumbs options"
+        p options
         builder = (options.delete(:builder) || Breadcrumbs::SimpleBuilder).new(self, breadcrumbs, options)
         content = builder.render.html_safe
         if block_given?

--- a/lib/breadcrumbs_on_rails/action_controller.rb
+++ b/lib/breadcrumbs_on_rails/action_controller.rb
@@ -69,10 +69,12 @@ module BreadcrumbsOnRails
           path = Utils.instance_proc(path) if eval.include?("path")
         end
 
+
+        append_prepend_options = filter_options[:options].slice(:append, :prepend)
         element_options = filter_options.delete(:options) || {}
 
         before_filter(filter_options) do |controller|
-          controller.send(:add_breadcrumb, name, path, element_options)
+          controller.send(:add_breadcrumb, name, path, element_options.merge!(append_prepend_options))
         end
       end
 

--- a/lib/breadcrumbs_on_rails/action_controller.rb
+++ b/lib/breadcrumbs_on_rails/action_controller.rb
@@ -20,6 +20,8 @@ module BreadcrumbsOnRails
     protected
 
     def add_breadcrumb(name, path = nil, options = {})
+      p "add_breadcrumb"
+      p options
       self.breadcrumbs << Breadcrumbs::Element.new(name, path, options)
     end
 
@@ -80,7 +82,7 @@ module BreadcrumbsOnRails
         p element_options.merge!(append_prepend_options)
 
         before_filter(filter_options) do |controller|
-          controller.send(:add_breadcrumb, name, path, {empty: "hash"})
+          controller.send(:add_breadcrumb, name, path, element_options.merge!(append_prepend_options))
         end
       end
 

--- a/lib/breadcrumbs_on_rails/action_controller.rb
+++ b/lib/breadcrumbs_on_rails/action_controller.rb
@@ -20,8 +20,6 @@ module BreadcrumbsOnRails
     protected
 
     def add_breadcrumb(name, path = nil, options = {})
-      p "add_breadcrumb"
-      p options
       self.breadcrumbs << Breadcrumbs::Element.new(name, path, options)
     end
 
@@ -63,8 +61,6 @@ module BreadcrumbsOnRails
     module ClassMethods
 
       def add_breadcrumb(name, path = nil, filter_options = {})
-        p "filter_options"
-        p filter_options
         # This isn't really nice here
         if eval = Utils.convert_to_set_of_strings(filter_options.delete(:eval), %w(name path))
           name = Utils.instance_proc(name) if eval.include?("name")
@@ -73,13 +69,10 @@ module BreadcrumbsOnRails
 
 
         append_prepend_options = filter_options.slice(:append, :prepend)
-        p "append_prepend_options"
-        p append_prepend_options
 
         element_options = filter_options.delete(:options) || {}
 
-        p "append_prepend_options merge"
-        p element_options.merge!(append_prepend_options)
+        element_options.merge!(append_prepend_options)
 
         before_filter(filter_options) do |controller|
           controller.send(:add_breadcrumb, name, path, element_options)
@@ -91,8 +84,6 @@ module BreadcrumbsOnRails
     module HelperMethods
 
       def render_breadcrumbs(options = {}, &block)
-        p "render_breadcrumbs options"
-        p options
         builder = (options.delete(:builder) || Breadcrumbs::SimpleBuilder).new(self, breadcrumbs, options)
         content = builder.render.html_safe
         if block_given?

--- a/lib/breadcrumbs_on_rails/action_controller.rb
+++ b/lib/breadcrumbs_on_rails/action_controller.rb
@@ -80,7 +80,7 @@ module BreadcrumbsOnRails
         p element_options.merge!(append_prepend_options)
 
         before_filter(filter_options) do |controller|
-          controller.send(:add_breadcrumb, name, path, element_options.merge!(append_prepend_options))
+          controller.send(:add_breadcrumb, name, path, {empty: "hash"})
         end
       end
 

--- a/lib/breadcrumbs_on_rails/action_controller.rb
+++ b/lib/breadcrumbs_on_rails/action_controller.rb
@@ -61,6 +61,8 @@ module BreadcrumbsOnRails
     module ClassMethods
 
       def add_breadcrumb(name, path = nil, filter_options = {})
+        p "filter_options"
+        p filter_options
         # This isn't really nice here
         if eval = Utils.convert_to_set_of_strings(filter_options.delete(:eval), %w(name path))
           name = Utils.instance_proc(name) if eval.include?("name")

--- a/lib/breadcrumbs_on_rails/action_controller.rb
+++ b/lib/breadcrumbs_on_rails/action_controller.rb
@@ -89,7 +89,9 @@ module BreadcrumbsOnRails
     module HelperMethods
 
       def render_breadcrumbs(options = {}, &block)
-        builder = (Breadcrumbs::SimpleBuilder).new(self, breadcrumbs, options)
+        p "render_breadcrumbs options"
+        p options
+        builder = (options.delete(:builder) || Breadcrumbs::SimpleBuilder).new(self, breadcrumbs, options)
         content = builder.render.html_safe
         if block_given?
           capture(content, &block)

--- a/lib/breadcrumbs_on_rails/action_controller.rb
+++ b/lib/breadcrumbs_on_rails/action_controller.rb
@@ -76,7 +76,7 @@ module BreadcrumbsOnRails
 
         element_options = filter_options.delete(:options) || {}
 
-        p "element_options.merge!(append_prepend_options)"
+        p "append_prepend_options merge"
         p element_options.merge!(append_prepend_options)
 
         before_filter(filter_options) do |controller|
@@ -89,7 +89,7 @@ module BreadcrumbsOnRails
     module HelperMethods
 
       def render_breadcrumbs(options = {}, &block)
-        builder = (options.delete(:builder) || Breadcrumbs::SimpleBuilder).new(self, breadcrumbs, options)
+        builder = (Breadcrumbs::SimpleBuilder).new(self, breadcrumbs, options)
         content = builder.render.html_safe
         if block_given?
           capture(content, &block)

--- a/lib/breadcrumbs_on_rails/action_controller.rb
+++ b/lib/breadcrumbs_on_rails/action_controller.rb
@@ -82,7 +82,7 @@ module BreadcrumbsOnRails
         p element_options.merge!(append_prepend_options)
 
         before_filter(filter_options) do |controller|
-          controller.send(:add_breadcrumb, name, path, element_options.merge!(append_prepend_options))
+          controller.send(:add_breadcrumb, name, path, element_options)
         end
       end
 

--- a/lib/breadcrumbs_on_rails/breadcrumbs.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs.rb
@@ -112,7 +112,7 @@ module BreadcrumbsOnRails
         if element.path == nil
           content = compute_name(element)
         else
-          content = @context.link_to_unless_current(compute_name(element), compute_path(element), element.options.each.map{|k, v| [k,v] if k != :append && k != :prepend}.to_h)
+          content = @context.link_to_unless_current(compute_name(element), compute_path(element), element.options.each.map{|k, v| [k,v] unless [:append, :prepend].include?(k)}.to_h)
         end
 
 

--- a/lib/breadcrumbs_on_rails/breadcrumbs.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs.rb
@@ -89,7 +89,7 @@ module BreadcrumbsOnRails
         p "element.options"
         p element.options
 
-        element_options = element.options
+        element_options = element.options.each.map{|k, v| [k,v] unless [:append, :prepend].include?(k)}.to_h
         p "element_options"
         p element_options
 
@@ -112,7 +112,7 @@ module BreadcrumbsOnRails
         if element.path == nil
           content = compute_name(element)
         else
-          content = @context.link_to_unless_current(compute_name(element), compute_path(element), element.options.each.map{|k, v| [k,v] unless [:append, :prepend].include?(k)}.to_h || {})
+          content = @context.link_to_unless_current(compute_name(element), compute_path(element), element_options)
         end
 
 

--- a/lib/breadcrumbs_on_rails/breadcrumbs.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs.rb
@@ -97,16 +97,17 @@ module BreadcrumbsOnRails
 
         # TODO Get prepend option
         if element.options[:prepend]
-          element_options.delete(:prepend)
+          # element_options.delete(:prepend)
         end
 
         # TODO get append option
         if element.options[:append]
-          element_options.delete(:append)
+          # element_options.delete(:append)
         end
         p "after delets element.options"
         p element.options
         p "after delets element_options"
+        element_options
 
         if element.path == nil
           content = compute_name(element)

--- a/lib/breadcrumbs_on_rails/breadcrumbs.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs.rb
@@ -90,13 +90,11 @@ module BreadcrumbsOnRails
 
         # TODO Get prepend option
         if element.options[:prepend]
-          prepend_option = element.options[:prepend]
           element_options.delete(:prepend)
         end
 
         # TODO get append option
         if element.options[:append]
-          append_option = element.options[:append]
           element_options.delete(:append)
         end
 
@@ -109,8 +107,8 @@ module BreadcrumbsOnRails
 
 
         # TODO add prepend option to content
-        if prepend_option
-          case prepend = prepend_option
+        if element.options[:prepend]
+          case prepend = element.options[:prepend]
             when String
               content = prepend.to_s.html_safe + content
             when Proc
@@ -120,8 +118,8 @@ module BreadcrumbsOnRails
         end
 
         # TODO add append option to content
-        if append_option
-          case append = append_option
+        if element.options[:append]
+          case append = element.options[:append]
             when String
               content = content + append.to_s.html_safe
             when Proc

--- a/lib/breadcrumbs_on_rails/breadcrumbs.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs.rb
@@ -97,12 +97,12 @@ module BreadcrumbsOnRails
 
         # TODO Get prepend option
         if element.options[:prepend]
-          element.options.delete(:prepend)
+          # element.options.delete(:prepend)
         end
 
         # TODO get append option
         if element.options[:append]
-          element.options.delete(:append)
+          # element.options.delete(:append)
         end
         p "after delets element.options"
         p element.options
@@ -112,13 +112,13 @@ module BreadcrumbsOnRails
         if element.path == nil
           content = compute_name(element)
         else
-          content = @context.link_to_unless_current(compute_name(element), compute_path(element), element.options)
+          content = @context.link_to_unless_current(compute_name(element), compute_path(element), element.options.each.map{|k, v| [k,v] if k != :append && k != :prepend}.to_h)
         end
 
 
         # TODO add prepend option to content
-        if element_options[:prepend]
-          case prepend = element_options[:prepend]
+        if element.options[:prepend]
+          case prepend = element.options[:prepend]
             when String
               content = prepend.to_s.html_safe + content
             when Proc
@@ -128,8 +128,8 @@ module BreadcrumbsOnRails
         end
 
         # TODO add append option to content
-        if element_options[:append]
-          case append = element_options[:append]
+        if element.options[:append]
+          case append = element.options[:append]
             when String
               content = content + append.to_s.html_safe
             when Proc

--- a/lib/breadcrumbs_on_rails/breadcrumbs.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs.rb
@@ -85,11 +85,49 @@ module BreadcrumbsOnRails
       end
 
       def render_element(element)
+
+        # TODO Get prepend option
+        if element.options[:prepend]
+          prepend_option = element.options[:prepend]
+          element.options.delete(:prepend)
+        end
+
+        # TODO get append option
+        if element.options[:append]
+          append_option = element.options[:append]
+          element.options.delete(:append)
+        end
+
         if element.path == nil
           content = compute_name(element)
         else
           content = @context.link_to_unless_current(compute_name(element), compute_path(element), element.options)
         end
+
+
+        # TODO add prepend option to content
+        if prepend_option
+          case prepend = prepend_option
+            when String
+              content = prepend.to_s.html_safe + content
+            when Proc
+              content = prepend.call.to_s.html_safe + content
+          end
+          content
+        end
+
+        # TODO add append option to content
+        if append_option
+          case append = append_option
+            when String
+              content = content + append.to_s.html_safe
+            when Proc
+              content = content + append.call.to_s.html_safe
+          end
+          content
+        end
+
+
         if @options[:tag]
           @context.content_tag(@options[:tag], content)
         else

--- a/lib/breadcrumbs_on_rails/breadcrumbs.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs.rb
@@ -86,7 +86,14 @@ module BreadcrumbsOnRails
 
       def render_element(element)
 
+        p "element.options"
+        p element.options
+
         element_options = element.options
+        p "element_options"
+        p element_options
+
+
 
         # TODO Get prepend option
         if element.options[:prepend]
@@ -97,7 +104,9 @@ module BreadcrumbsOnRails
         if element.options[:append]
           element_options.delete(:append)
         end
-
+        p "after delets element.options"
+        p element.options
+        p "after delets element_options"
 
         if element.path == nil
           content = compute_name(element)

--- a/lib/breadcrumbs_on_rails/breadcrumbs.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs.rb
@@ -112,7 +112,7 @@ module BreadcrumbsOnRails
         if element.path == nil
           content = compute_name(element)
         else
-          content = @context.link_to_unless_current(compute_name(element), compute_path(element), element.options.each.map{|k, v| [k,v] unless [:append, :prepend].include?(k)}.to_h)
+          content = @context.link_to_unless_current(compute_name(element), compute_path(element), element.options.each.map{|k, v| [k,v] unless [:append, :prepend].include?(k)}.to_h || {})
         end
 
 

--- a/lib/breadcrumbs_on_rails/breadcrumbs.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs.rb
@@ -97,12 +97,12 @@ module BreadcrumbsOnRails
 
         # TODO Get prepend option
         if element.options[:prepend]
-          # element_options.delete(:prepend)
+          element.options.delete(:prepend)
         end
 
         # TODO get append option
         if element.options[:append]
-          # element_options.delete(:append)
+          element.options.delete(:append)
         end
         p "after delets element.options"
         p element.options
@@ -112,13 +112,13 @@ module BreadcrumbsOnRails
         if element.path == nil
           content = compute_name(element)
         else
-          content = @context.link_to_unless_current(compute_name(element), compute_path(element), element_options)
+          content = @context.link_to_unless_current(compute_name(element), compute_path(element), element.options)
         end
 
 
         # TODO add prepend option to content
-        if element.options[:prepend]
-          case prepend = element.options[:prepend]
+        if element_options[:prepend]
+          case prepend = element_options[:prepend]
             when String
               content = prepend.to_s.html_safe + content
             when Proc
@@ -128,8 +128,8 @@ module BreadcrumbsOnRails
         end
 
         # TODO add append option to content
-        if element.options[:append]
-          case append = element.options[:append]
+        if element_options[:append]
+          case append = element_options[:append]
             when String
               content = content + append.to_s.html_safe
             when Proc

--- a/lib/breadcrumbs_on_rails/breadcrumbs.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs.rb
@@ -89,7 +89,7 @@ module BreadcrumbsOnRails
         p "element.options"
         p element.options
 
-        element_options = element.options.each.map{|k, v| [k,v] unless [:append, :prepend].include?(k)}.to_h
+        element_options = element.options.except(:append, :prepend)
         p "element_options"
         p element_options
 
@@ -107,12 +107,12 @@ module BreadcrumbsOnRails
         p "after delets element.options"
         p element.options
         p "after delets element_options"
-        element_options
+        p element_options
 
         if element.path == nil
           content = compute_name(element)
         else
-          content = @context.link_to_unless_current(compute_name(element), compute_path(element), element_options)
+          content = @context.link_to_unless_current(compute_name(element), compute_path(element), element.options.except(:append, :prepend))
         end
 
 

--- a/lib/breadcrumbs_on_rails/breadcrumbs.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs.rb
@@ -86,29 +86,6 @@ module BreadcrumbsOnRails
 
       def render_element(element)
 
-        p "element.options"
-        p element.options
-
-        element_options = element.options.except(:append, :prepend)
-        p "element_options"
-        p element_options
-
-
-
-        # TODO Get prepend option
-        if element.options[:prepend]
-          # element.options.delete(:prepend)
-        end
-
-        # TODO get append option
-        if element.options[:append]
-          # element.options.delete(:append)
-        end
-        p "after delets element.options"
-        p element.options
-        p "after delets element_options"
-        p element_options
-
         if element.path == nil
           content = compute_name(element)
         else

--- a/lib/breadcrumbs_on_rails/breadcrumbs.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs.rb
@@ -86,22 +86,25 @@ module BreadcrumbsOnRails
 
       def render_element(element)
 
+        element_options = element.options
+
         # TODO Get prepend option
         if element.options[:prepend]
           prepend_option = element.options[:prepend]
-          element.options.delete(:prepend)
+          element_options.delete(:prepend)
         end
 
         # TODO get append option
         if element.options[:append]
           append_option = element.options[:append]
-          element.options.delete(:append)
+          element_options.delete(:append)
         end
+
 
         if element.path == nil
           content = compute_name(element)
         else
-          content = @context.link_to_unless_current(compute_name(element), compute_path(element), element.options)
+          content = @context.link_to_unless_current(compute_name(element), compute_path(element), element_options)
         end
 
 

--- a/lib/breadcrumbs_on_rails/breadcrumbs.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs.rb
@@ -89,7 +89,7 @@ module BreadcrumbsOnRails
         if element.path == nil
           content = compute_name(element)
         else
-          content = @context.link_to_unless_current(compute_name(element), compute_path(element), element.options)
+          content = @context.link_to_unless_current(compute_name(element), compute_path(element), element.options.except(:append, :prepend))
         end
 
 

--- a/lib/breadcrumbs_on_rails/breadcrumbs.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs.rb
@@ -89,7 +89,7 @@ module BreadcrumbsOnRails
         if element.path == nil
           content = compute_name(element)
         else
-          content = @context.link_to_unless_current(compute_name(element), compute_path(element), element.options.except(:append, :prepend))
+          content = @context.link_to_unless_current(compute_name(element), compute_path(element), element.options)
         end
 
 

--- a/lib/breadcrumbs_on_rails/railtie.rb
+++ b/lib/breadcrumbs_on_rails/railtie.rb
@@ -9,7 +9,7 @@
 module BreadcrumbsOnRails
 
   class Railtie < Rails::Railtie
-    initializer "breadcrumbs_on_rails.initialize" do
+    config.before_configuration do
       ActiveSupport.on_load(:action_controller) do
         include BreadcrumbsOnRails::ActionController
       end

--- a/lib/breadcrumbs_on_rails/version.rb
+++ b/lib/breadcrumbs_on_rails/version.rb
@@ -11,7 +11,7 @@ module BreadcrumbsOnRails
   module Version
     MAJOR = 2
     MINOR = 3
-    PATCH = 1
+    PATCH = 2
     BUILD = nil
 
     STRING = [MAJOR, MINOR, PATCH, BUILD].compact.join('.')


### PR DESCRIPTION
with append and prepend options you can add custom content before or after breadcrumb link, lik a bootstrap icons html content.
Example `add_breadcrumb 'Home', :root_path, prepend: '<i class="fa fa-dashboard"></i>', append: '<i class="fa fa-dashboard"></i>'`

will generate this content
http://i.imgur.com/oDldO2w.png

