### PR TITLE
Allowing the name to be passed as a block

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require 'bundler/gem_tasks'
 require 'appraisal'
+require 'rake/clean'
 
 if !ENV["APPRAISAL_INITIALIZED"] && !ENV["TRAVIS"]
   task :default => :appraisal

--- a/lib/breadcrumbs_on_rails/action_controller.rb
+++ b/lib/breadcrumbs_on_rails/action_controller.rb
@@ -23,7 +23,9 @@ module BreadcrumbsOnRails
 
     protected
 
-    def add_breadcrumb(name, path = nil, options = {})
+    def add_breadcrumb(name = nil, path = nil, options = nil, &block)
+      options, path, name = path, name, block if block_given?
+      options ||= {}
       self.breadcrumbs << Breadcrumbs::Element.new(name, path, options)
     end
 
@@ -64,7 +66,10 @@ module BreadcrumbsOnRails
 
     module ClassMethods
 
-      def add_breadcrumb(name, path = nil, filter_options = {})
+      def add_breadcrumb(name = nil, path = nil, filter_options = nil, &block)
+        filter_options, path, name = path, name, block if block_given?
+        filter_options ||= {}
+
         # This isn't really nice here
         if eval = Utils.convert_to_set_of_strings(filter_options.delete(:eval), %w(name path))
           name = Utils.instance_proc(name) if eval.include?("name")

--- a/test/unit/action_controller_test.rb
+++ b/test/unit/action_controller_test.rb
@@ -17,6 +17,9 @@ class ExampleController < ActionController::Base
     add_breadcrumb "String", "/"
     add_breadcrumb "Proc", proc { |c| "/?proc" }
     add_breadcrumb "Polymorphic", [:admin, :namespace]
+    add_breadcrumb "/name_block" do
+      "Name Block"
+    end
     execute("action_default")
   end
 
@@ -47,7 +50,7 @@ class ExampleControllerTest < ActionController::TestCase
 
   def test_render_compute_paths
     get :action_compute_paths
-    assert_dom_equal  %(<a href="/">String</a> &raquo; <a href="/?proc">Proc</a> &raquo; <a href="/?polymorphic">Polymorphic</a>),
+    assert_dom_equal  %(<a href="/">String</a> &raquo; <a href="/?proc">Proc</a> &raquo; <a href="/?polymorphic">Polymorphic</a> &raquo; <a href="/name_block">Name Block</a>),
                       @response.body.to_s
   end
 
@@ -60,6 +63,9 @@ class ClassLevelExampleController < ActionController::Base
   add_breadcrumb "Proc", proc { |c| "/?proc" }
   add_breadcrumb "Polymorphic", [:admin, :namespace]
   add_breadcrumb "With options", "/", :options => { :title => "Awesome" }
+  add_breadcrumb "/", :options => { :title => "Title Options" } do
+    "Name Block"
+  end
 
   def action_default
     render 'example/default'
@@ -82,10 +88,11 @@ class ClassLevelExampleControllerTest < ActionController::TestCase
       links << '<a href="/?proc">Proc</a>'
       links << '<a href="/?polymorphic">Polymorphic</a>'
       links << '<a title="Awesome" href="/">With options</a>'
+      links << '<a title="Title Options" href="/">Name Block</a>'
     }
 
     get :action_default
-    assert_dom_equal  expected.join(" &raquo; "), 
+    assert_dom_equal  expected.join(" &raquo; "),
                       @response.body.to_s
   end
 
@@ -107,4 +114,3 @@ class ExampleHelpersTest < ActionView::TestCase
   end
 
 end
-


### PR DESCRIPTION
Allows for translations to be used from the add_breadcrumb in the controller and prevents the controller from caching it.

```
class SomeController < ApplicationController
  ...
  add_breadcrumb :connections_path do
    I18n.t('some_key.breadcrumb')
  end
  ...
end