### PR TITLE
 Add wrapper support to allow more customization without need for builder

### DIFF
--- a/lib/breadcrumbs_on_rails/breadcrumbs.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs.rb
@@ -92,6 +92,9 @@ module BreadcrumbsOnRails
         end
         if @options[:tag]
           @context.content_tag(@options[:tag], content)
+        elsif @options[:wrapper]
+          is_current_page = element.path && @context.current_page?(compute_path(element))
+          @options[:wrapper].call(content, is_current_page)
         else
           ERB::Util.h(content)
         end

--- a/lib/breadcrumbs_on_rails/breadcrumbs.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs.rb
@@ -93,8 +93,8 @@ module BreadcrumbsOnRails
         if @options[:tag]
           @context.content_tag(@options[:tag], content)
         elsif @options[:wrapper]
-          is_current_page = element.path && @context.current_page?(compute_path(element))
-          @options[:wrapper].call(content, is_current_page)
+          current = element.path && @context.current_page?(compute_path(element))
+          @options[:wrapper].call(content, current)
         else
           ERB::Util.h(content)
         end

--- a/test/unit/simple_builder_test.rb
+++ b/test/unit/simple_builder_test.rb
@@ -87,12 +87,13 @@ class SimpleBuilderTest < ActionView::TestCase
   def test_render_with_wrapper
     @template.expects(:current_page?).times(2).returns(true, true)
     assert_dom_equal(
-      "<li class='breadcrumb-item active'>Element 1</li>",
+      "<li class='active'>Element 1</li>",
       simplebuilder(@template,
                     generate_elements(1),
-                    wrapper: ->(el, is_current_page) {
-                      tag.li(el, class: is_current_page ? 'breadcrumb-item active' : 'breadcrumb-item')
-                    }).render)
+                    wrapper: lambda do |el, current|
+                      tag.li(el, class: current ? 'active' : '')
+                    end
+                   ).render)
   end
 
   protected

--- a/test/unit/simple_builder_test.rb
+++ b/test/unit/simple_builder_test.rb
@@ -84,6 +84,17 @@ class SimpleBuilderTest < ActionView::TestCase
                      simplebuilder(@template, elements, {tag: :li} ).render)
   end
 
+  def test_render_with_wrapper
+    @template.expects(:current_page?).times(2).returns(true, true)
+    assert_dom_equal(
+      "<li class='breadcrumb-item active'>Element 1</li>",
+      simplebuilder(@template,
+                    generate_elements(1),
+                    wrapper: ->(el, is_current_page) {
+                      tag.li(el, class: is_current_page ? 'breadcrumb-item active' : 'breadcrumb-item')
+                    }).render)
+  end
+
   protected
 
   def simplebuilder(*args)

--- a/test/unit/simple_builder_test.rb
+++ b/test/unit/simple_builder_test.rb
@@ -84,16 +84,16 @@ class SimpleBuilderTest < ActionView::TestCase
                      simplebuilder(@template, elements, {tag: :li} ).render)
   end
 
-  def test_render_with_wrapper
+  def test_render_with_current_page_and_wrapper
     @template.expects(:current_page?).times(2).returns(true, true)
     assert_dom_equal(
       "<li class='active'>Element 1</li>",
       simplebuilder(@template,
                     generate_elements(1),
                     wrapper: lambda do |el, current|
-                      tag.li(el, class: current ? 'active' : '')
-                    end
-                   ).render)
+                      content_tag(:li, el, class: current ? 'active' : '')
+                    end).render
+    )
   end
 
   protected


### PR DESCRIPTION
Allows this:
`<%= render_breadcrumbs :wrapper => ->(element, _) { content_tag(:li, element) } %>`
or this:
```
<%=
  render_breadcrumbs :wrapper => lambda |element, current| do
    class = current ? 'active' : ''
    content_tag(:li, element, class: class)
  end
%>
```