### PR TITLE
Update README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The third, optional argument is a Hash of options to customize the breadcrumb li
 ```ruby
 class MyController
   def index
-    add_breadcrumb "index", index_path, :title => "Back to the Index"
+    add_breadcrumb "index", index_path, options: { title: "Back to the Index" } }
   end
 end
 ```


### PR DESCRIPTION
The element options are taken from the :options field of the options hash passed into `add_breadcrumb` but the documentation seems to suggest otherwise.

This commit updates the documentation to reflect the correct usage.