### PR TITLE
CI: Remove Ruby 2.4 (EOL); use Bundler 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 
 rvm:
-  - 2.4
   - 2.5
   - 2.6
   - 2.7
@@ -23,9 +22,4 @@ gemfile:
 matrix:
   allow_failures:
     - rvm: ruby-head
-  exclude:
-    - rvm: 2.4
-      gemfile: gemfiles/6.0.gemfile
 
-before_install:
-  - gem install bundler -v 1.17.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 
 rvm:
-  - 2.5
   - 2.6
   - 2.7
+  - 3.0
   - ruby-head
 
 env:

--- a/breadcrumbs_on_rails.gemspec
+++ b/breadcrumbs_on_rails.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = "BreadcrumbsOnRails is a simple Ruby on Rails plugin for creating and managing a breadcrumb navigation for a Rails project."
   spec.licenses      = ["MIT"]
 
-  spec.required_ruby_version = ">= 2.4"
+  spec.required_ruby_version = ">= 2.5"
 
   spec.require_paths = ["lib"]
   spec.files         = `git ls-files`.split("\n")

--- a/breadcrumbs_on_rails.gemspec
+++ b/breadcrumbs_on_rails.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = "BreadcrumbsOnRails is a simple Ruby on Rails plugin for creating and managing a breadcrumb navigation for a Rails project."
   spec.licenses      = ["MIT"]
 
-  spec.required_ruby_version = ">= 2.5"
+  spec.required_ruby_version = ">= 2.6"
 
   spec.require_paths = ["lib"]
   spec.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
This PR removes an unsupported Ruby, and drops Bundler 1-specific installation in the CI configuration.

Drops support for Ruby 2.4.

See https://www.ruby-lang.org/en/downloads/branches/ for the maintenance schedule of Ruby.