### PR TITLE
Swap dependency on "rails" to "railties"

### DIFF
--- a/breadcrumbs_on_rails.gemspec
+++ b/breadcrumbs_on_rails.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   spec.extra_rdoc_files = %w( LICENSE.txt )
 
-  spec.add_dependency "rails", ">= 5.0"
+  spec.add_dependency "railties", ">= 5.0"
 end


### PR DESCRIPTION
This allows users to use this gem without pulling in actioncable/activestorage/etc, and thus reduce their dependency footprint.

Closes https://github.com/weppos/breadcrumbs_on_rails/issues/135