### PR TITLE
CI: YAML-quote the 3.0 to avoid Float-to-String misconversion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 rvm:
   - 2.6
   - 2.7
-  - 3.0
+  - "3.0"
   - ruby-head
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 
 rvm:
-  - 2.6
-  - 2.7
+  - "2.6"
+  - "2.7"
   - "3.0"
   - ruby-head
 


### PR DESCRIPTION
This PR avoids a 3.0 -> 3 -> "3" misconversion.