### PR TITLE
Add breadcrumbs_for which accepts a context (Symbol) and groups the breadcrumbs added into groups.

### DIFF
--- a/lib/breadcrumbs_on_rails/action_controller.rb
+++ b/lib/breadcrumbs_on_rails/action_controller.rb
@@ -15,7 +15,7 @@ module BreadcrumbsOnRails
       extend          ClassMethods
       helper          HelperMethods
       helper_method   :add_breadcrumb_on_rails, :add_breadcrumb,
-                      :breadcrumbs_on_rails, :breadcrumbs
+                      :breadcrumbs_on_rails, :breadcrumbs, :breadcrumbs_for
 
       unless base.respond_to?(:before_action)
         base.alias_method :before_action, :before_filter
@@ -31,15 +31,34 @@ module BreadcrumbsOnRails
     # @param  options [Hash]
     # @return [void]
     def add_breadcrumb_on_rails(name, path = nil, options = {})
-      breadcrumbs_on_rails << Breadcrumbs::Element.new(name, path, options)
+      breadcrumbs_on_rails[@current_context || :default] << Breadcrumbs::Element.new(name, path, options)
     end
     alias add_breadcrumb add_breadcrumb_on_rails
+
+    # # Added to topnav context
+    #
+    # breadscrumbs_for(:topnav) do
+    #   add_breadcrumb "Home", root_path
+    # end
+    #
+    # # Added to default context
+    #
+    # add_breadcrumb "About", about_path
+    #
+    def breadcrumbs_for(context, &block)
+      breadcrumbs_on_rails[context] ||= []
+      @current_context = context
+      yield
+      @current_context = nil
+    end
+
+    # render_breadcrumbs_for(:topnav)
 
     # Gets the list of all breadcrumb element in the collection.
     #
     # @return [Array<Breadcrumbs::Element>]
     def breadcrumbs_on_rails
-      @breadcrumbs_on_rails ||= []
+      @breadcrumbs_on_rails ||= {default: []}
     end
     alias breadcrumbs breadcrumbs_on_rails
 
@@ -60,7 +79,7 @@ module BreadcrumbsOnRails
     module HelperMethods
 
       def render_breadcrumbs(options = {}, &block)
-        builder = (options.delete(:builder) || Breadcrumbs::SimpleBuilder).new(self, breadcrumbs_on_rails, options)
+        builder = (options.delete(:builder) || Breadcrumbs::SimpleBuilder).new(self, breadcrumbs_on_rails[options.delete(:context) || :default], options)
         content = builder.render.html_safe
         if block_given?
           capture(content, &block)

--- a/test/unit/action_controller_test.rb
+++ b/test/unit/action_controller_test.rb
@@ -20,6 +20,19 @@ class ExampleController < ActionController::Base
     execute("action_default")
   end
 
+  def action_grouped_breadcrumbs
+    breadcrumbs_for(:first) do
+      add_breadcrumb "Alpha", "/alpha"
+      add_breadcrumb "Beta", "/beta"
+    end
+
+    breadcrumbs_for(:second) do
+      add_breadcrumb "Charlie", "/charlie"
+      add_breadcrumb "Delta", "/delta"
+    end
+
+    execute("action_default")
+  end
 
   private
 
@@ -51,6 +64,17 @@ class ExampleControllerTest < ActionController::TestCase
                       @response.body.to_s
   end
 
+  def test_render_first_group_of_breadcrumbs
+    get :action_grouped_breadcrumbs, params: {template: 'first_group'}
+    assert_dom_equal  %(<a href="/alpha">Alpha</a> &raquo; <a href="/beta">Beta</a>),
+                      @response.body.to_s
+  end
+
+  def test_render_second_group_of_breadcrumbs
+    get :action_grouped_breadcrumbs, params: {template: 'second_group'}
+    assert_dom_equal  %(<a href="/charlie">Charlie</a> &raquo; <a href="/delta">Delta</a>),
+                      @response.body.to_s
+  end
 end
 
 class ClassLevelExampleController < ActionController::Base
@@ -99,7 +123,7 @@ class ExampleHelpersTest < ActionView::TestCase
   attr_accessor :breadcrumbs_on_rails
 
   setup do
-    self.breadcrumbs_on_rails = []
+    self.breadcrumbs_on_rails = {default: []}
   end
 
   def test_render_breadcrumbs

--- a/test/views/example/first_group.html.erb
+++ b/test/views/example/first_group.html.erb
@@ -1,0 +1,1 @@
+<%= render_breadcrumbs(context: :first) %>

--- a/test/views/example/second_group.html.erb
+++ b/test/views/example/second_group.html.erb
@@ -1,0 +1,1 @@
+<%= render_breadcrumbs(context: :second) %>


### PR DESCRIPTION
Now you can do this:

```ruby
def index
  breadcrumbs_for(:primary) do
    add_breadcrumb "Alpha", "/alpha"
    add_breadcrumb "Beta", "/beta"
  end

  breadcrumbs_for(:secondary) do
    add_breadcrumb "Charlie", "/charlie"
    add_breadcrumb "Delta", "/delta"
  end

  # This will be added to the "default" context
  add_breadcrumb "Echo", "/echo"
end
```

### Primary

```erb
<%= render_breadcrumbs(context: :primary) %>
```

```html
<a href="/alpha">Alpha</a> &raquo; <a href="/beta">Beta</a>
```

### Secondary

```erb
<%= render_breadcrumbs(context: :secondary) %>
```

```html
<a href="/charlie">Charlie</a> &raquo; <a href="/delta">Delta</a>
```

### Default

```erb
<%= render_breadcrumbs %>
```

```html
<a href="/echo">Echo</a>
```