### PR TITLE
Add CI Ruby 3.3 - 3.2 & Rails 8.0 - 6.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,15 +10,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - gemfile: "6.0"
-            ruby-version: "2.6"
-          - gemfile: "6.0"
-            ruby-version: "2.7"
-          - gemfile: "6.0"
-            ruby-version: "3.0"
-          - gemfile: "6.0"
-            ruby-version: "3.1"
+        ruby-version: ['3.3', '3.2', '3.1', '3.0', '2.7', '2.6']
+        gemfile: ['8.0', '7.2', '7.1', '7.0', '6.1', '6.0']
+        exclude:
+          # rails 8.0: support ruby 3.2+
+          - gemfile: '8.0'
+            ruby-version: '3.1'
+          - gemfile: '8.0'
+            ruby-version: '3.0'
+          - gemfile: '8.0'
+            ruby-version: '2.7'
+          - gemfile: '8.0'
+            ruby-version: '2.6'
+          # rails 7.2: support ruby 3.1+
+          - gemfile: '7.2'
+            ruby-version: '3.0'
+          - gemfile: '7.2'
+            ruby-version: '2.7'
+          - gemfile: '7.2'
+            ruby-version: '2.6'
+          # rails 7.1/7.0: support ruby 2.7+
+          - gemfile: '7.1'
+            ruby-version: '2.6'
+          - gemfile: '7.0'
+            ruby-version: '2.6'
     runs-on: ubuntu-latest
     name: rails ${{ matrix.gemfile }}, ruby ${{ matrix.ruby-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
     name: rails ${{ matrix.gemfile }}, ruby ${{ matrix.ruby-version }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/Appraisals
+++ b/Appraisals
@@ -10,3 +10,18 @@ end
 appraise "6.0" do
   gem "rails", "~> 6.0.0"
 end
+appraise "6.1" do
+  gem "rails", "~> 6.1.0"
+end
+appraise "7.0" do
+  gem "rails", "~> 7.0.0"
+end
+appraise "7.1" do
+  gem "rails", "~> 7.1.0"
+end
+appraise "7.2" do
+  gem "rails", "~> 7.2.0"
+end
+appraise "8.0" do
+  gem "rails", "~> 8.0.0"
+end

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -9,4 +9,4 @@ gem "rails", "~> 5.0.0"
 gem "mocha", ">= 1.0"
 gem "yard"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/5.1.gemfile
+++ b/gemfiles/5.1.gemfile
@@ -9,4 +9,4 @@ gem "rails", "~> 5.1.0"
 gem "mocha", ">= 1.0"
 gem "yard"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/5.2.gemfile
+++ b/gemfiles/5.2.gemfile
@@ -9,4 +9,4 @@ gem "rails", "~> 5.2.0"
 gem "mocha", ">= 1.0"
 gem "yard"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/6.1.gemfile
+++ b/gemfiles/6.1.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "rake"
 gem "bundler"
 gem "appraisal"
-gem "rails", "~> 6.0.0"
+gem "rails", "~> 6.1.0"
 gem "mocha", ">= 1.0"
 gem "yard"
 

--- a/gemfiles/7.0.gemfile
+++ b/gemfiles/7.0.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "rake"
 gem "bundler"
 gem "appraisal"
-gem "rails", "~> 6.0.0"
+gem "rails", "~> 7.0.0"
 gem "mocha", ">= 1.0"
 gem "yard"
 

--- a/gemfiles/7.1.gemfile
+++ b/gemfiles/7.1.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "rake"
 gem "bundler"
 gem "appraisal"
-gem "rails", "~> 6.0.0"
+gem "rails", "~> 7.1.0"
 gem "mocha", ">= 1.0"
 gem "yard"
 

--- a/gemfiles/7.2.gemfile
+++ b/gemfiles/7.2.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "rake"
 gem "bundler"
 gem "appraisal"
-gem "rails", "~> 6.0.0"
+gem "rails", "~> 7.2.0"
 gem "mocha", ">= 1.0"
 gem "yard"
 

--- a/gemfiles/8.0.gemfile
+++ b/gemfiles/8.0.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "rake"
 gem "bundler"
 gem "appraisal"
-gem "rails", "~> 6.0.0"
+gem "rails", "~> 8.0.0"
 gem "mocha", ">= 1.0"
 gem "yard"
 


### PR DESCRIPTION
This Pull Request expands the limited range of versions currently tested in the CI pipeline.
At present, the CI tests only Rails 6.0 with Ruby versions 2.6 to 3.1.

To improve test coverage, this PR adds the following to the CI matrix:

- Rails versions: 8.0, 7.2, 7.1, 7.0, and 6.1
- Ruby versions: 3.3 and 3.2

### Additional information

The compatibility between Rails and Ruby versions is outlined below:

```
Rails 8.0 requires Ruby 3.2.0 or newer.
Rails 7.2 requires Ruby 3.1.0 or newer.
Rails 7.0 and 7.1 requires Ruby 2.7.0 or newer.
Rails 6 requires Ruby 2.5.0 or newer.
```
For more details, refer to https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#ruby-versions
